### PR TITLE
Bash, CSS, HTML, Python, Typescript basic support. Javascript and Ruby improvements.

### DIFF
--- a/Alabaster.icls
+++ b/Alabaster.icls
@@ -1,9 +1,9 @@
 <scheme name="Alabaster" version="142" parent_scheme="Default">
   <metaInfo>
-    <property name="created">2020-11-19T00:21:38</property>
+    <property name="created">2020-12-26T14:51:25</property>
     <property name="ide">idea</property>
-    <property name="ideVersion">2020.2.3.0.0</property>
-    <property name="modified">2020-11-19T00:21:51</property>
+    <property name="ideVersion">2020.2.4.0.0</property>
+    <property name="modified">2020-12-26T14:51:37</property>
     <property name="originalScheme">Alabaster</property>
   </metaInfo>
   <colors>
@@ -25,6 +25,22 @@
         <option name="FOREGROUND" value="cc3333" />
         <option name="BACKGROUND" value="ffcccc" />
       </value>
+    </option>
+    <option name="BASH.EXTERNAL_COMMAND" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="BASH.FUNCTION_DEF_NAME">
+      <value>
+        <option name="FOREGROUND" value="3e7e" />
+        <option name="BACKGROUND" value="dbf1ff" />
+      </value>
+    </option>
+    <option name="BASH.HERE_DOC">
+      <value>
+        <option name="FOREGROUND" value="64200" />
+        <option name="BACKGROUND" value="e5fad7" />
+      </value>
+    </option>
+    <option name="CSS.PROPERTY_VALUE">
+      <value />
     </option>
     <option name="CTRL_CLICKABLE">
       <value>
@@ -362,6 +378,9 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
+    <option name="HTML_CODE">
+      <value />
+    </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="7acc" />
@@ -397,8 +416,8 @@
     <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES" />
     <option name="JS.EXPORTED.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="3e73" />
-        <option name="BACKGROUND" value="dbf1ff" />
+        <option name="FOREGROUND" value="0" />
+        <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
     <option name="JS.EXPORTED.VARIABLE">
@@ -406,27 +425,35 @@
     </option>
     <option name="JS.GLOBAL_FUNCTION">
       <value>
-        <option name="FOREGROUND" value="3e73" />
-        <option name="BACKGROUND" value="dbf1ff" />
+        <option name="FOREGROUND" value="0" />
+        <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="JS.GLOBAL_VARIABLE">
-      <value />
-    </option>
+    <option name="JS.GLOBAL_VARIABLE" baseAttributes="DEFAULT_GLOBAL_VARIABLE" />
     <option name="JS.INSTANCE_MEMBER_FUNCTION">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="0" />
+        <option name="BACKGROUND" value="ffffff" />
+      </value>
     </option>
     <option name="JS.LOCAL_FUNCTION">
       <value>
-        <option name="FOREGROUND" value="3e7e" />
-        <option name="BACKGROUND" value="dbf1ff" />
+        <option name="FOREGROUND" value="0" />
+        <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="JS.LOCAL_VARIABLE">
-      <value />
+    <option name="JS.LOCAL_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
+    <option name="JS.PARAMETER">
+      <value>
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
     </option>
-    <option name="JS.PARAMETER" baseAttributes="DEFAULT_PARAMETER" />
-    <option name="JS.REGEXP" baseAttributes="DEFAULT_STRING" />
+    <option name="JS.REGEXP">
+      <value>
+        <option name="FOREGROUND" value="64200" />
+        <option name="BACKGROUND" value="c0ecaa" />
+      </value>
+    </option>
     <option name="JS.STATIC_MEMBER_FUNCTION">
       <value />
     </option>
@@ -485,8 +512,8 @@
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="0" />
-        <option name="BACKGROUND" value="efefef" />
+        <option name="BACKGROUND" value="99ccbb" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
@@ -495,48 +522,86 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
+    <option name="PY.BUILTIN_NAME">
+      <value />
+    </option>
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="3e7e" />
+        <option name="BACKGROUND" value="dbf1ff" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value />
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value />
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value />
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="64200" />
+        <option name="BACKGROUND" value="e5fad7" />
+      </value>
+    </option>
+    <option name="RDOC_DIRECTIVE">
+      <value />
+    </option>
+    <option name="RDOC_EMAIL">
+      <value>
+        <option name="FOREGROUND" value="64200" />
+        <option name="BACKGROUND" value="e5fad7" />
+      </value>
+    </option>
+    <option name="RDOC_HEADINGS">
+      <value />
+    </option>
+    <option name="RDOC_IDENTIFIER">
+      <value />
+    </option>
+    <option name="RDOC_KEYWORD">
+      <value />
+    </option>
+    <option name="RDOC_URL">
+      <value>
+        <option name="FOREGROUND" value="64200" />
+        <option name="BACKGROUND" value="e5fad7" />
+      </value>
+    </option>
     <option name="RUBY_CONSTANT">
       <value />
     </option>
     <option name="RUBY_CONSTANT_DECLARATION">
       <value />
     </option>
-    <option name="RUBY_GVAR" baseAttributes="DEFAULT_GLOBAL_VARIABLE" />
     <option name="RUBY_HASH_ASSOC">
-      <value />
-    </option>
-    <option name="RUBY_HASH_KEY">
       <value />
     </option>
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="64200" />
-        <option name="BACKGROUND" value="c0ecaa" />
+        <option name="BACKGROUND" value="e5fad7" />
       </value>
     </option>
-    <option name="RUBY_HEREDOC_ID">
-      <value>
-        <option name="FOREGROUND" value="64200" />
-        <option name="BACKGROUND" value="c0ecaa" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
+    <option name="RUBY_LOCAL_VAR_ID">
+      <value />
     </option>
-    <option name="RUBY_LINE_CONTINUATION" baseAttributes="DEFAULT_COMMA" />
-    <option name="RUBY_LOCAL_VAR_ID" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
     <option name="RUBY_METHOD_NAME">
       <value>
         <option name="FOREGROUND" value="3e7e" />
         <option name="BACKGROUND" value="dbf1ff" />
       </value>
     </option>
-    <option name="RUBY_NTH_REF" baseAttributes="DEFAULT_PREDEFINED_SYMBOL" />
-    <option name="RUBY_PARAMDEF_CALL">
-      <value>
-        <option name="FOREGROUND" value="3e7e" />
-        <option name="BACKGROUND" value="dbf1ff" />
-      </value>
+    <option name="RUBY_PARAMETER_ID">
+      <value />
     </option>
-    <option name="RUBY_PARAMETER_ID" baseAttributes="DEFAULT_PARAMETER" />
     <option name="RUBY_REGEXP">
       <value>
         <option name="FOREGROUND" value="64200" />
@@ -550,9 +615,37 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
+    <option name="SASS_MIXIN">
+      <value />
+    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="ffbc5d" />
+      </value>
+    </option>
+    <option name="SPY-JS.EXCEPTION">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.FUNCTION_SCOPE">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.PATH_LEVEL_ONE">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.PATH_LEVEL_TWO">
+      <value>
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="SPY-JS.PROGRAM_SCOPE">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
@@ -582,6 +675,21 @@
         <option name="FOREGROUND" value="695900" />
         <option name="BACKGROUND" value="fffabc" />
       </value>
+    </option>
+    <option name="TS.CLASS">
+      <value />
+    </option>
+    <option name="TS.INSTANCE_MEMBER_FUNCTION">
+      <value />
+    </option>
+    <option name="TS.STATIC_MEMBER_FUNCTION">
+      <value />
+    </option>
+    <option name="TS.TYPE_GUARD">
+      <value />
+    </option>
+    <option name="TS.TYPE_PARAMETER">
+      <value />
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value />


### PR DESCRIPTION
1. JS functions are black on white now because IDEA doesn't support method call vs method declaration distinction for JS: https://youtrack.jetbrains.com/issue/WEB-44685.

2. No highlighting of type related constructs in Typescript. Should look like Java version.

3. Ruby OOP constructs were detected as constants and methods were detected as text, fixed it.

4. Basic support for Python. (Don't know it well, just made it black on white except methods, comments, constants and strings).

4. Small changes to Bash, CSS/SASS, etc. Highlight strings and methods correctly, do not highlight situational constructs.

P.S. Sorry about errors in previous PR.