### PR TITLE
Add highlighting for predefined Python methods

### DIFF
--- a/Alabaster.icls
+++ b/Alabaster.icls
@@ -629,7 +629,11 @@
       <value />
     </option>
     <option name="PY.PREDEFINED_DEFINITION">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="3e7e" />
+        <option name="BACKGROUND" value="dbf1ff" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
     </option>
     <option name="PY.PREDEFINED_USAGE">
       <value />


### PR DESCRIPTION
Highlighting of predefined methods makes sense too
![image](https://user-images.githubusercontent.com/1122191/113701809-4dae2b00-96e1-11eb-9458-1654fefc64a4.png)
