### PR TITLE
Include dark version in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ Other languages work perfectly fine as well, but may do some extra unnecessary h
 
 ## Installation
 
-1. Download [Alabaster.icls](https://raw.githubusercontent.com/tonsky/intellij-alabaster/master/Alabaster.icls).
+1. Download [Alabaster.icls] or [Alabaster Dark.icls].
 2. Import through Preferences → Editor → Color scheme → Import Scheme...
 
+[Alabaster.icls]: https://raw.githubusercontent.com/tonsky/intellij-alabaster/master/Alabaster.icls
+[Alabaster Dark.icls]: https://raw.githubusercontent.com/tonsky/intellij-alabaster/master/Alabaster%20Dark.icls
+
 ![Installation](installation.png)
+
 
 ## License
 


### PR DESCRIPTION
Add direct link to Dark version in installation instructions (otherwise people might not see it).

Use reference-style links to keep the file readable.