### PR TITLE
Update link for JetBrains IDE plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Other languages work perfectly fine as well, but may do some extra unnecessary h
 
 - Version for Sublime Text [tonsky/sublime-scheme-alabaster](https://github.com/tonsky/sublime-scheme-alabaster)
 - Version for Visual Studio Code [tonsky/vscode-theme-alabaster](https://github.com/tonsky/vscode-theme-alabaster)
-- for JetBrains IDEs as a plugin [vlnabatov/alabaster-theme](https://github.com/vlnabatov/alabaster-theme)
-- for JetBrains IDEs as a plugin (dark version) [vlnabatov/alabaster-dark-theme](https://github.com/vlnabatov/alabaster-dark-theme)
+- For JetBrains IDEs as a plugin [nabato/alabaster-themes](https://github.com/nabato/alabaster-themes)
 - Version for Vim [agudulin/vim-colors-alabaster](https://github.com/agudulin/vim-colors-alabaster)
 - Alternative version for Sublime Text 2 [freetonik/Travertine](https://github.com/freetonik/Travertine)
 - Dark version for VS Code [apust/vscode-rubber-theme](https://github.com/apust/vscode-rubber-theme)


### PR DESCRIPTION
Hey,

I was just passing by and noticed that one of the link was broken. As far as I understand, the author of JetBrains IDE plugin version merged two repos into one. Also they have renamed their Github account since then.

So I've removed the broken link and updated the working one.

Hope it's fine.